### PR TITLE
Enforce both legacy and normative exp formats in tokens

### DIFF
--- a/lib/prx_auth/token.ex
+++ b/lib/prx_auth/token.ex
@@ -45,15 +45,9 @@ defmodule PrxAuth.Token do
   end
 
   def expired?(%{"iat" => iat, "exp" => exp}) do
-    now = :os.system_time(:seconds)
-
-    cond do
-      iat > now -> true
-      iat <= exp -> expired?(exp)
-      true -> expired?(exp + iat)
-    end
+    if iat <= exp, do: expired?(exp), else: expired?(exp + iat)
   end
 
   def expired?(%{"exp" => exp}), do: expired?(exp)
-  def expired?(exp), do: :os.system_time(:seconds) > exp
+  def expired?(exp), do: :os.system_time(:seconds) - 30 > exp
 end

--- a/lib/prx_auth/token.ex
+++ b/lib/prx_auth/token.ex
@@ -1,16 +1,27 @@
 defmodule PrxAuth.Token do
-
   def verify(_cert, _iss, nil), do: {:no_token}
+
   def verify(cert, iss, jwt) do
     jwk = JOSE.JWK.from_pem(cert)
+
     cond do
-      !valid?(jwt) -> {:invalid}
-      issuer(jwt) != iss -> {:bad_issuer}
-      jwk == [] -> {:bad_cert}
+      !valid?(jwt) ->
+        {:invalid}
+
+      issuer(jwt) != iss ->
+        {:bad_issuer}
+
+      jwk == [] ->
+        {:bad_cert}
+
       true ->
         case JOSE.JWT.verify(jwk, jwt) do
-          {:error, _err} -> {:failed}
-          {false, _claims, _jws} -> {:failed}
+          {:error, _err} ->
+            {:failed}
+
+          {false, _claims, _jws} ->
+            {:failed}
+
           {true, claims, _jws} ->
             if expired?(claims.fields), do: {:expired}, else: {:ok, claims.fields}
         end
@@ -35,6 +46,7 @@ defmodule PrxAuth.Token do
 
   def expired?(%{"iat" => iat, "exp" => exp}) do
     now = :os.system_time(:seconds)
+
     cond do
       iat > now -> true
       iat <= exp -> expired?(exp)

--- a/lib/prx_auth/token.ex
+++ b/lib/prx_auth/token.ex
@@ -33,7 +33,15 @@ defmodule PrxAuth.Token do
     end
   end
 
-  def expired?(%{"iat" => iat, "exp" => exp}), do: :os.system_time(:seconds) > (iat + exp)
-  def expired?(%{"exp" => exp}), do: :os.system_time(:seconds) > exp
-  def expired?(_), do: false
+  def expired?(%{"iat" => iat, "exp" => exp}) do
+    now = :os.system_time(:seconds)
+    cond do
+      iat > now -> true
+      iat <= exp -> expired?(exp)
+      true -> expired?(exp + iat)
+    end
+  end
+
+  def expired?(%{"exp" => exp}), do: expired?(exp)
+  def expired?(exp), do: :os.system_time(:seconds) > exp
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule PrxAuth.Mixfile do
   def project do
     [
       app: :prx_auth,
-      version: "0.2.0",
+      version: "0.3.0",
       elixir: "~> 1.2",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,

--- a/test/prx_auth/token_test.exs
+++ b/test/prx_auth/token_test.exs
@@ -68,8 +68,8 @@ defmodule PrxAuth.TokenTest do
     now = :os.system_time(:seconds)
     assert expired?(%{}) == false
     assert expired?(%{"iat" => now - 10}) == false
-    assert expired?(%{"exp" => now - 100}) == true
-    assert expired?(%{"exp" => now + 10}) == false
+    assert expired?(%{"iat" => now - 150, "exp" => now - 100}) == true
+    assert expired?(%{"iat" => now - 10, "exp" => now + 10}) == false
     assert expired?(%{"iat" => now - 10, "exp" => 5}) == true
     assert expired?(%{"iat" => now - 10, "exp" => 15}) == false
   end

--- a/test/prx_auth/token_test.exs
+++ b/test/prx_auth/token_test.exs
@@ -13,7 +13,7 @@ defmodule PrxAuth.TokenTest do
     token_type: "bearer",
     scope: "profile email address phone read-private",
     aur: %{"123456" => "admin"},
-    iss: "id.prx.org",
+    iss: "id.prx.org"
   }
 
   def claim(claims) do


### PR DESCRIPTION
For PRX/id.prx.org#145